### PR TITLE
Require that hubs respond with a hub.lease_seconds.

### DIFF
--- a/pubsubhubbub-core-0.4.xml
+++ b/pubsubhubbub-core-0.4.xml
@@ -215,8 +215,8 @@
 
             <t hangText="hub.lease_seconds">OPTIONAL. Number of seconds for
             which the subscriber would like to have the subscription active. If
-            not present or an empty value, hubs SHOULD provide a default value
-            upon <xref target="verifysub">verification of intent</xref>.Hubs MAY 
+            not present or an empty value, hubs MUST provide a value upon
+            <xref target="verifysub">verification of intent</xref>.Hubs MAY 
             choose to respect this value or not, depending on their own policies. 
             This parameter MAY be present for unsubscription requests and MUST be
             ignored by the hub in that case.</t>


### PR DESCRIPTION
Because now all subscriptions are ephemeral the hub should respond with a hub.lease_seconds on every subscription.

At some point we should add an appendix with best practices to suggest that hubs should have both a min_lease_seconds and max_lease_seconds. I noticed that pubsubhubbub.appspot.com does not have a min_lease_seconds which is bad. A malicious user can subscribe lots of endpoints (which are on another site) with lease_seconds = 1 which might end up with a hub performing a DOS attach on the target site. That's not cool :-)
