### PR TITLE
spelling fixes

### DIFF
--- a/pubsubhubbub-core-0.3.html
+++ b/pubsubhubbub-core-0.3.html
@@ -154,7 +154,7 @@
 <h3>Abstract</h3>
 
 <p>An open, simple, web-scale pubsub protocol, along with an open source
-      reference implentation targetting Google App Engine. Notably, however,
+      reference implentation targeting Google App Engine. Notably, however,
       nothing in the protocol is centralized, or Google- or App
       Engine-specific. Anybody can play.
 </p>

--- a/pubsubhubbub-core-0.4.xml
+++ b/pubsubhubbub-core-0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <?xml-stylesheet type='text/xsl' href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
-<!-- For editting this, see: http://xml.resource.org/public/rfc/html/rfc2629.html
+<!-- For editing this, see: http://xml.resource.org/public/rfc/html/rfc2629.html
  In a nutshell,
  $ sudo apt-get install xml2rfc
  $ xml2rfc pubsubhubbub-core-0.1.xml pubsubhubbub-core-0.1.html

--- a/pubsubhubbub-core.xml
+++ b/pubsubhubbub-core.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type='text/xsl' href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
 <!--
-  For editting this, see:
+  For editing this, see:
 
   http://xml.resource.org/public/rfc/html/rfc2629.html
 
@@ -58,7 +58,7 @@
 
     <abstract>
       <t>An open, simple, web-scale pubsub protocol, along with an open source
-      reference implentation targetting Google App Engine. Notably, however,
+      reference implentation targeting Google App Engine. Notably, however,
       nothing in the protocol is centralized, or Google- or App
       Engine-specific. Anybody can play.</t>
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.